### PR TITLE
Feature/29449 footnote improvements

### DIFF
--- a/php/class-editor.php
+++ b/php/class-editor.php
@@ -7,19 +7,44 @@ namespace Editor_Footnotes;
 class Editor {
 	use Singleton;
 
+	/**
+	 * Setup the singleton.
+	 */
 	public function setup() {
 		add_filter( 'mce_buttons', [ $this, 'add_buttons' ] );
 		add_filter( 'mce_external_plugins', [ $this, 'register_plugins' ] );
-		add_editor_style( URL . 'static/css/editor-plugin.css' );
+		add_action( 'wp_enqueue_editor', [ $this, 'wp_enqueue_editor' ] );
 	}
 
+	/**
+	 * Register this TinyMCE plugin.
+	 *
+	 * @param  array $plugin_array Array of plugins
+	 * @return array
+	 */
 	public function register_plugins( $plugin_array ) {
 		$plugin_array['editor_footnotes'] = URL . '/static/js/editor-plugin.js';
 		return $plugin_array;
 	}
 
+	/**
+	 * Add the footnotes icon to the toolbar.
+	 *
+	 * @param array $buttons Toolbar buttons.
+	 */
 	public function add_buttons( $buttons ) {
-		$buttons[] = 'editor_footnotes';
+		if ( false !== ( $insert_point = array_search( 'unlink', $buttons ) ) ) {
+			array_splice( $buttons, $insert_point + 1, 0, 'editor_footnotes' );
+		} else {
+			$buttons[] = 'editor_footnotes';
+		}
 		return $buttons;
+	}
+
+	/**
+	 * Enqueue the required CSS when WP enqueues the editor scripts and styles.
+	 */
+	public function wp_enqueue_editor() {
+		wp_enqueue_style( 'editor-footnotes-css', URL . '/static/css/editor-plugin.css', [], '0.1' );
 	}
 }

--- a/php/class-editor.php
+++ b/php/class-editor.php
@@ -10,6 +10,7 @@ class Editor {
 	public function setup() {
 		add_filter( 'mce_buttons', [ $this, 'add_buttons' ] );
 		add_filter( 'mce_external_plugins', [ $this, 'register_plugins' ] );
+		add_editor_style( URL . 'static/css/editor-plugin.css' );
 	}
 
 	public function register_plugins( $plugin_array ) {

--- a/static/css/editor-plugin.css
+++ b/static/css/editor-plugin.css
@@ -1,25 +1,16 @@
-p {
-	/* TODO this is only applying to the content not mce UI */
-	/* see this is applied to content */
-	/* background-color: beige; */
-}
+/* TODO this is only applying to the content not mce UI */
 
-/* this is not applied to UI scope */
-div.footnote-preview {
+/* enable to quickly see if this is applied to content
+p {
+	background-color: beige;
+}
+*/
+
+/* but what we want is this to be applied to UI scope */
+.footnote-preview {
 	float: left;
 	margin: 5px;
 	max-width: 694px;
 	overflow: hidden;
 	text-overflow: ellipsis;
-}
-
-div.footnote-preview span {
-	color: #0073aa;
-	-webkit-transition-property: border, background, color;
-	transition-property: border, background, color;
-	-webkit-transition-duration: .05s;
-	transition-duration: .05s;
-	-webkit-transition-timing-function: ease-in-out;
-	transition-timing-function: ease-in-out;
-	cursor: pointer;
 }

--- a/static/css/editor-plugin.css
+++ b/static/css/editor-plugin.css
@@ -7,7 +7,7 @@ p {
 */
 
 /* but what we want is this to be applied to UI scope */
-.footnote-preview {
+.mce-container .footnote-preview {
 	float: left;
 	margin: 5px;
 	max-width: 694px;
@@ -15,8 +15,14 @@ p {
 	text-overflow: ellipsis;
 }
 
-.footnote-input {
+.mce-container .footnote-input {
 	float: left;
 	margin: 2px;
 	max-width: 694px;
+	min-width: 400px;
+}
+
+.mce-container .footnote-input textarea {
+	width: 100%;
+	white-space: pre-wrap;
 }

--- a/static/css/editor-plugin.css
+++ b/static/css/editor-plugin.css
@@ -14,3 +14,9 @@ p {
 	overflow: hidden;
 	text-overflow: ellipsis;
 }
+
+.footnote-input {
+	float: left;
+	margin: 2px;
+	max-width: 694px;
+}

--- a/static/css/editor-plugin.css
+++ b/static/css/editor-plugin.css
@@ -1,12 +1,3 @@
-/* TODO this is only applying to the content not mce UI */
-
-/* enable to quickly see if this is applied to content
-p {
-	background-color: beige;
-}
-*/
-
-/* but what we want is this to be applied to UI scope */
 .mce-container .footnote-preview {
 	float: left;
 	margin: 5px;
@@ -25,4 +16,5 @@ p {
 .mce-container .footnote-input textarea {
 	width: 100%;
 	white-space: pre-wrap;
+	background-color: #FFFFFF;
 }

--- a/static/css/editor-plugin.css
+++ b/static/css/editor-plugin.css
@@ -1,0 +1,25 @@
+p {
+	/* TODO this is only applying to the content not mce UI */
+	/* see this is applied to content */
+	/* background-color: beige; */
+}
+
+/* this is not applied to UI scope */
+div.footnote-preview {
+	float: left;
+	margin: 5px;
+	max-width: 694px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+div.footnote-preview span {
+	color: #0073aa;
+	-webkit-transition-property: border, background, color;
+	transition-property: border, background, color;
+	-webkit-transition-duration: .05s;
+	transition-duration: .05s;
+	-webkit-transition-timing-function: ease-in-out;
+	transition-timing-function: ease-in-out;
+	cursor: pointer;
+}

--- a/static/js/editor-plugin.js
+++ b/static/js/editor-plugin.js
@@ -174,6 +174,7 @@
     editor.addButton('editor_footnotes', {
       icon: 'dashicon dashicons-format-status',
       tooltip: 'Insert Footnote',
+      stateSelector: 'span.footnote',
       cmd: 'footnote_edit',
       onPostRender: function() {
         var self = this;

--- a/static/js/editor-plugin.js
+++ b/static/js/editor-plugin.js
@@ -18,11 +18,10 @@
 
   tinymce.ui.footnoteInput = tinymce.ui.Control.extend( {
     renderHtml: function() {
-      // TODO - remove inline styles when css hooked up correctly
       return (
         '<div id="' + this._id + '" class="footnote-input">' +
-          '<textarea hidefocus="1" rows="5" placeholder="' + tinymce.translate( 'Enter Footnote' ) +
-          '" style="background-color: white;"></textarea>' +
+          '<textarea rows="5" placeholder="' +
+          tinymce.translate( 'Enter Footnote' ) + '"></textarea>' +
         '</div>'
       );
     },
@@ -153,7 +152,11 @@
         text = inputInstance.getFootnoteText();
         editor.focus();
 
-        editor.dom.setAttribs( footnoteNode, { 'data-footnote': text, 'data-footnote-edit': null } );
+        if (text) {
+          editor.dom.setAttribs( footnoteNode, { 'data-footnote': text, 'data-footnote-edit': null } );          
+        } else {
+          editor.execCommand('footnote_remove');
+        }
       }
 
       inputInstance.reset();
@@ -196,7 +199,17 @@
     editor.addButton( 'footnote_input', {
       type: 'footnoteInput',
       onPostRender: function() {
+        var element = this.getEl(),
+          input = element.firstChild;
+
         inputInstance = this;
+
+        tinymce.$( input ).on( 'keydown', function( event ) {
+          if ( event.keyCode === 13 ) {
+            editor.execCommand( 'footnote_apply' );
+            event.preventDefault();
+          }
+        } );
       }
     } );
 

--- a/static/js/editor-plugin.js
+++ b/static/js/editor-plugin.js
@@ -21,7 +21,7 @@
       // TODO - remove inline styles when css hooked up correctly
       return (
         '<div id="' + this._id + '" class="footnote-input">' +
-          '<textarea hidefocus="1" rows="3" placeholder="' + tinymce.translate( 'Enter Footnote' ) +
+          '<textarea hidefocus="1" rows="5" placeholder="' + tinymce.translate( 'Enter Footnote' ) +
           '" style="background-color: white;"></textarea>' +
         '</div>'
       );
@@ -213,7 +213,7 @@
 
         if ( edit ) {
           if ( footnoteText ) {
-            inputInstance.setFootnoteText( footnoteText );            
+            inputInstance.setFootnoteText( footnoteText );
           }
           event.element = footnoteNode;
           event.toolbar = editToolbar;

--- a/static/js/editor-plugin.js
+++ b/static/js/editor-plugin.js
@@ -48,11 +48,22 @@ tinymce.PluginManager.add('editor_footnotes', function(editor, url) {
           // editor.insertContent('Title: ' + e.data.footnote);
 
           var text = editor.selection.getContent({ 'format' : 'raw' });
-          if (text && text.length > 0) {
+
+          if (footnoteNode) {
+            // if already exists, then don't nest another inside
+            footnoteNode.setAttribute('data-footnote', e.data.footnote);
+          } else if (text && text.length > 0) {
             var $node = $( '<span class="footnote" />' ).attr( 'data-footnote', e.data.footnote ).text( text );
             editor.insertContent( $node[0].outerHTML );
           }
         }
+      });
+    },
+    onPostRender: function() {
+      var self = this;
+
+      editor.on('NodeChange', function(event) {
+        self.disabled(!getSelectedFootnote() && '' === editor.selection.getContent());
       });
     }
   });

--- a/static/js/editor-plugin.js
+++ b/static/js/editor-plugin.js
@@ -54,7 +54,7 @@
     var $ = window.jQuery;
 
     function getSelectedFootnote() {
-      var footnote, html,
+      var content, html,
         node = editor.selection.getNode(),
         span = editor.dom.getParent( node, 'span[data-footnote]' );
 
@@ -78,7 +78,7 @@
     }
 
     function setPlaceholder() {
-      var text, $node;
+      var text, $placeholder;
       text = editor.selection.getContent( { format: 'raw' } );
       $placeholder = $( '<span class="footnote" />' ).attr( 'data-footnote-edit', true )
                                                      .attr( 'data-footnote', '' )
@@ -106,7 +106,7 @@
         toolbar = editor.wp._createToolbar( [
           'footnote_preview',
           'footnote_edit',
-          'footnote_remove',
+          'footnote_remove'
         ], true );
 
         var editButtons = [
@@ -201,7 +201,7 @@
     } );
 
     editor.on( 'wptoolbar', function( event ) {
-      var $footnoteNode, footnote, footnoteText, edit;
+      var $footnoteNode, footnoteText, edit;
 
       footnoteNode = editor.dom.hasClass(event.element, 'footnote') ? event.element :
         editor.dom.getParent( event.element, 'span.footnote' );


### PR DESCRIPTION
https://work.alley.ws/issues/29449

This refactors this footnote plugin to mirror the `wplink` mce plugin.

But there is an issue with the stylesheet. At least locally, it is only applying to the content iframe - not the mce floating toolbars which are outside of that in the admin page. I'm not sure how to get the styles to that context from the plugin - maybe `admin_enqueue_styles()`?
